### PR TITLE
Fix wildcard target evaluation, package loading errors, and DevTools output path conflicts

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -2,3 +2,8 @@
 # generated build artifacts, which causes severe performance degradation
 # and potential package conflicts during analysis.
 out
+third_party/boringssl/src
+third_party/perfetto/src
+third_party/cpu_features/src
+third_party/emsdk/bazel
+third_party/icu/source

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -3,7 +3,6 @@
 # bits and re-apply fixes from version control.
 
 load("@dart_packages//:defs.bzl", "declare_package_targets")
-load("@rules_cc//cc:defs.bzl", "cc_library")
 load("//tools/bazel/dart:defs.bzl", "dart_library")
 
 package(default_visibility = ["//visibility:public"])
@@ -160,7 +159,7 @@ filegroup(
     ),
 )
 
-cc_library(
+filegroup(
     name = "analysis_server",
     # //utils/analysis_server:analysis_server is now the real app-jit snapshot
     # genrule (not a cc_library), so it rides via `data`, not `deps`.
@@ -169,53 +168,53 @@ cc_library(
     ],
 )
 
-cc_library(
+filegroup(
     name = "create_platform_sdk",
-    deps = [
+    srcs = [
         "//sdk:create_platform_sdk",
     ],
 )
 
-cc_library(
+filegroup(
     name = "create_sdk",
-    deps = [
+    srcs = [
         "//sdk:create_sdk",
     ],
 )
 
-cc_library(
+filegroup(
     name = "dart2js",
-    deps = [
+    srcs = [
         "//:runtime_precompiled",
         "//utils/compiler:dart2js_sdk_aot",
     ],
 )
 
-cc_library(
+filegroup(
     name = "dart2js_bot",
-    deps = [
+    srcs = [
         "//:create_sdk",
         "//utils/compiler:compile_dart2js_platform",
     ],
 )
 
-cc_library(
+filegroup(
     name = "dart2wasm",
-    deps = [
+    srcs = [
         "//:dart2wasm_platform",
         "//utils/dart2wasm:test_wasm_modules",
     ],
 )
 
-cc_library(
+filegroup(
     name = "dart2wasm_benchmark",
-    deps = [
+    srcs = [
         "//:dart2wasm_platform",
         "//third_party/binaryen:wasm-opt",
     ],
 )
 
-cc_library(
+filegroup(
     name = "dart2wasm_platform",
     data = [
         "//utils/dart2wasm:compile_dart2wasm_js_compatibility_platform",
@@ -224,44 +223,44 @@ cc_library(
         "//utils/dart2wasm:dart2wasm_asserts_snapshot",
         "//utils/dart2wasm:dart2wasm_snapshot",
     ],
-    deps = [
+    srcs = [
         "//:runtime_precompiled",
     ],
 )
 
-cc_library(
+filegroup(
     name = "dartanalyzer",
-    deps = [
+    srcs = [
         "//utils/dartanalyzer",
     ],
 )
 
-cc_library(
+filegroup(
     name = "ddc",
-    deps = [
+    srcs = [
         "//:runtime_precompiled",
         "//utils/bazel:kernel_worker_aot",
         "//utils/ddc:dartdevc_aot",
     ],
 )
 
-cc_library(
+filegroup(
     name = "debian_package",
-    deps = [
+    srcs = [
         "//tools/debian_package",
     ],
 )
 
-cc_library(
+filegroup(
     name = "default",
-    deps = [
+    srcs = [
         "//:runtime",
     ],
 )
 
-cc_library(
+filegroup(
     name = "most",
-    deps = [
+    srcs = [
         "//:analysis_server",
         "//:create_sdk",
         "//:dart2js",
@@ -271,16 +270,16 @@ cc_library(
     ],
 )
 
-cc_library(
+filegroup(
     name = "run_ffi_unit_tests",
-    deps = [
+    srcs = [
         "//runtime/bin/ffi_unit_test:run_ffi_unit_tests",
     ],
 )
 
-cc_library(
+filegroup(
     name = "runtime",
-    deps = [
+    srcs = [
         "//runtime/bin:abstract_socket_test",
         "//runtime/bin:analyze_snapshot",
         "//runtime/bin:dart",
@@ -309,9 +308,9 @@ cc_library(
     ],
 )
 
-cc_library(
+filegroup(
     name = "runtime_precompiled",
-    deps = [
+    srcs = [
         "//runtime/bin:abstract_socket_test",
         "//runtime/bin:dartaotruntime",
         "//runtime/bin:gen_snapshot",
@@ -320,9 +319,9 @@ cc_library(
     ],
 )
 
-cc_library(
+filegroup(
     name = "tools",
-    deps = [
+    srcs = [
         "//utils:compile_platform.exe",
         "//utils:gen_kernel.exe",
     ],

--- a/docs/bazel-migration/BACKLOG.md
+++ b/docs/bazel-migration/BACKLOG.md
@@ -15,7 +15,7 @@ This is the single source of truth for the remaining migration work stream. It i
 
 - **Active Agent**: `[none]`
 - **Global Lock**: `[unlocked]`
-- **Overall Progress**: 26/34 Tasks
+- **Overall Progress**: 27/35 Tasks
 
 ---
 
@@ -61,6 +61,7 @@ graph TD
     TASK_032["TASK_032:<br>Fix package config generator for workspace packages and dynamic language versions"]:::completed
     TASK_033["TASK_033:<br>Fix SDK packaging VM product mode configuration mismatch"]:::pending
     TASK_034["TASK_034:<br>Add Chrome/Firefox test configurations to Bazel target generator"]:::pending
+    TASK_035["TASK_035:<br>Fix Bazel wildcard target evaluation and package loading errors"]:::completed
 
     TASK_017 --> TASK_006
     TASK_010 --> TASK_012
@@ -802,3 +803,32 @@ graph TD
   - [ ] Chrome/Firefox test configurations are defined in `generate_test_targets.dart`.
   - [ ] Bazel generates `tests_wasm_chrome_release` targets under the `@dart_tests` repository.
   - [ ] E2E browser tests compile, spin up Chrome via chromedriver in the sandbox, and pass cleanly.
+
+---
+
+### 🎯 [TASK_035] Fix Bazel wildcard target evaluation and package loading errors
+- **Status**: `[COMPLETED]`
+- **Prerequisites**: None
+- **Owner**: `[jetski]`
+- **Commit**: `[local]`
+- **Target Files**:
+  - `tools/bazel/BUILD.bazel`
+  - `.bazelignore`
+  - `BUILD.bazel`
+  - `sdk/BUILD.bazel`
+  - `tools/bazel/dart/defs.bzl`
+  - `utils/ddc/BUILD.bazel`
+- **Description**:
+  Resolve workspace-wide wildcard parsing (`//...`) failures and package loading errors by:
+  1. Removing deleted `out_of_band` directories from the exports glob.
+  2. Adding unignored upstream third-party checkouts under `third_party/` to `.bazelignore`.
+  3. Converting generic wrapper/stub targets in `BUILD.bazel` and `utils/ddc/BUILD.bazel` from `cc_library` to `filegroup`.
+  4. Resolving DevTools target output path conflicts by introducing a staging rule `copy_directory`.
+- **Verification Command**:
+  ```bash
+  bazel fetch //...
+  ```
+- **Success Criteria**:
+  - [x] Wildcard target queries (`bazel fetch //...`) complete successfully without package loading or analysis errors.
+  - [x] Conflicting action issues for built-from-source vs. prebuilt DevTools targets are resolved.
+

--- a/docs/bazel-migration/STATUS.md
+++ b/docs/bazel-migration/STATUS.md
@@ -26,6 +26,13 @@
 **Active claims (who is editing what right now):**
 - `[none]`
 
+Session 109 — **(jetski) Resolved workspace-wide wildcard target evaluation and package loading errors.**
+- **Fixed Empty Glob Loading Error**: Corrected `tools/bazel/BUILD.bazel` to only export `parse_deps.py` after the deletion of the `out_of_band/` directory, resolving package loading errors during wildcard scans.
+- **Added Upstream Ignores to .bazelignore**: Appended `third_party/boringssl/src`, `third_party/perfetto/src`, `third_party/cpu_features/src`, `third_party/emsdk/bazel`, and `third_party/icu/source` to `.bazelignore` to prevent Bazel from scanning unignored upstream build files.
+- **Converted wrappers to filegroups**: Converted mock/stub/wrapper `cc_library` targets (like `//:dart2js`, `//utils/ddc:ddc_canary_test`, etc.) to `filegroup` targets in `BUILD.bazel` and `utils/ddc/BUILD.bazel` to prevent CcInfo provider validation errors.
+- **Resolved DevTools Staging Path Conflict**: Modified `build_devtools` and `copy_prebuilt_devtools` to write to unique output directories under the `sdk` package. Appended a custom `copy_directory` Starlark rule to `tools/bazel/dart/defs.bzl` and introduced a `//sdk:copy_devtools` target to stage the selected DevTools output dynamically.
+- **Verified Build**: Confirmed `bazel fetch //...` completes successfully, and both `bazel build //sdk:create_sdk` and `bazel build //runtime/bin:dartvm` build 100% green.
+
 Session 108 — **(jetski) Fixed dart2wasm compiler snapshot product compatibility mismatch.**
 - **Identified and Fixed Snapshot Product Mismatch**: Resolved a test failure where executing dart2wasm tests in Bazel would crash because `dartaotruntime` (always product mode) mismatched the compiler snapshot `dart2wasm_product.snapshot` (staged as non-product release mode).
 - **Updated BUILD.bazel**: Modified `copy_dart2wasm_snapshot` in `sdk/BUILD.bazel` to always source the product snapshot (`//utils/dart2wasm:dart2wasm_product_snapshot`).

--- a/sdk/BUILD.bazel
+++ b/sdk/BUILD.bazel
@@ -3,7 +3,7 @@
 # bits and re-apply fixes from version control.
 
 load("@rules_cc//cc:defs.bzl", "cc_library")
-load("//tools/bazel/dart:defs.bzl", "build_devtools_rule", "copy_internal_with_dills", "copy_sdk_library", "copy_tree")
+load("//tools/bazel/dart:defs.bzl", "build_devtools_rule", "copy_directory", "copy_internal_with_dills", "copy_sdk_library", "copy_tree")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -59,7 +59,7 @@ build_devtools_rule(
     srcs = [
         "//tools:utils.py",
     ],
-    out_dir = "dart-sdk/bin/resources/devtools",
+    out_dir = "dart-sdk/bin/resources/devtools_built",
 )
 
 copy_sdk_library(
@@ -684,8 +684,17 @@ filegroup(
 copy_tree(
     name = "copy_prebuilt_devtools",
     srcs = ["//:prebuilt_devtools_files"],
-    out_dir = "dart-sdk/bin/resources/devtools",
+    out_dir = "dart-sdk/bin/resources/devtools_prebuilt",
     src_dir = "third_party/devtools/web",
+)
+
+copy_directory(
+    name = "copy_devtools",
+    src_dir = select({
+        "//build/config:devtools_from_sources": "//sdk:build_devtools",
+        "//conditions:default": "//sdk:copy_prebuilt_devtools",
+    }),
+    out_dir = "dart-sdk/bin/resources/devtools",
 )
 
 # GN renames README.dart-sdk -> README at the SDK root.
@@ -785,10 +794,8 @@ filegroup(
         "//sdk:write_dartdoc_options",
         "//sdk:write_revision_file",
         "//sdk:write_version_file",
-    ] + select({
-        "//build/config:devtools_from_sources": ["//sdk:build_devtools"],
-        "//conditions:default": ["//sdk:copy_prebuilt_devtools"],
-    }),
+        "//sdk:copy_devtools",
+    ],
 )
 
 filegroup(

--- a/tools/bazel/BUILD.bazel
+++ b/tools/bazel/BUILD.bazel
@@ -1,3 +1,3 @@
 # Empty build file to designate tools/bazel as a valid Bazel package.
 
-exports_files(glob(["out_of_band/**/*"]) + ["parse_deps.py"])
+exports_files(["parse_deps.py"])

--- a/tools/bazel/dart/defs.bzl
+++ b/tools/bazel/dart/defs.bzl
@@ -691,3 +691,27 @@ build_devtools_rule = rule(
         ),
     },
 )
+
+def _copy_directory_impl(ctx):
+    in_dir = ctx.files.src_dir[0]
+    out_dir = ctx.actions.declare_directory(ctx.attr.out_dir)
+    ctx.actions.run_shell(
+        inputs = [in_dir],
+        outputs = [out_dir],
+        command = "rm -rf {out} && cp -R {src} {out}".format(
+            src = in_dir.path,
+            out = out_dir.path,
+        ),
+        mnemonic = "CopyDirectory",
+        progress_message = "Copying directory to %s" % ctx.attr.out_dir,
+    )
+    return [DefaultInfo(files = depset([out_dir]))]
+
+copy_directory = rule(
+    implementation = _copy_directory_impl,
+    attrs = {
+        "src_dir": attr.label(mandatory = True),
+        "out_dir": attr.string(mandatory = True),
+    },
+)
+

--- a/utils/ddc/BUILD.bazel
+++ b/utils/ddc/BUILD.bazel
@@ -2,7 +2,7 @@
 # Hand-fixes belong in this file (M3); rerun the translator to refresh structural
 # bits and re-apply fixes from version control.
 
-load("@rules_cc//cc:defs.bzl", "cc_library")
+# Empty build file to designate utils/ddc as a valid Bazel package.
 load("//tools/bazel/dart:defs.bzl", "dart_aot_snapshot", "dart_app_jit_snapshot", "dart_compile_platform")
 
 package(default_visibility = ["//visibility:public"])
@@ -83,33 +83,33 @@ dart_aot_snapshot(
 # kernel dill). No stub here.
 
 # TODO(M3): genrule for ddc_canary_sdk (gn type=action)
-cc_library(name = "ddc_canary_sdk")
+filegroup(name = "ddc_canary_sdk")
 
 # TODO(M3): genrule for ddc_canary_sdk_ddc_module (gn type=action)
-cc_library(name = "ddc_canary_sdk_ddc_module")
+filegroup(name = "ddc_canary_sdk_ddc_module")
 
-cc_library(
+filegroup(
     name = "ddc_canary_test",
     # dartdevc is now a genrule (app-jit snapshot) -> carry via data, not deps.
     data = ["//utils/ddc:dartdevc"],
-    deps = [
+    srcs = [
         "//:create_sdk",
         "//utils/ddc:ddc_canary_test_local",
     ],
 )
 
-cc_library(
+filegroup(
     name = "ddc_canary_test_local",
-    deps = [
+    srcs = [
         "//utils/ddc:ddc_canary_sdk",
         "//utils/ddc:ddc_canary_sdk_ddc_module",
         "//utils/ddc:ddc_canary_test_pkg",
     ],
 )
 
-cc_library(
+filegroup(
     name = "ddc_canary_test_pkg",
-    deps = [
+    srcs = [
         "//utils/ddc:ddc_test_pkg_outline",
         "//utils/ddc:expect_canary_ddc_js",
         "//utils/ddc:expect_canary_js",
@@ -121,7 +121,7 @@ cc_library(
 )
 
 # TODO(M3): genrule for ddc_files_stamp (gn type=action)
-cc_library(name = "ddc_files_stamp")
+filegroup(name = "ddc_files_stamp")
 
 # rules_dart Step 2a (first compile_platform WEB variant). Ports
 # utils/ddc/BUILD.gn:compile_platform("ddc_platform") — the DDC SDK platform dill
@@ -146,32 +146,32 @@ dart_compile_platform(
 )
 
 # TODO(M3): genrule for ddc_sdk_patch_stamp (gn type=action)
-cc_library(name = "ddc_sdk_patch_stamp")
+filegroup(name = "ddc_sdk_patch_stamp")
 
 # TODO(M3): genrule for ddc_stable_sdk (gn type=action)
-cc_library(name = "ddc_stable_sdk")
+filegroup(name = "ddc_stable_sdk")
 
-cc_library(
+filegroup(
     name = "ddc_stable_test",
     # dartdevc is now a genrule (app-jit snapshot) -> carry via data, not deps.
     data = ["//utils/ddc:dartdevc"],
-    deps = [
+    srcs = [
         "//:create_sdk",
         "//utils/ddc:ddc_stable_test_local",
     ],
 )
 
-cc_library(
+filegroup(
     name = "ddc_stable_test_local",
-    deps = [
+    srcs = [
         "//utils/ddc:ddc_stable_sdk",
         "//utils/ddc:ddc_stable_test_pkg",
     ],
 )
 
-cc_library(
+filegroup(
     name = "ddc_stable_test_pkg",
-    deps = [
+    srcs = [
         "//utils/ddc:ddc_test_pkg_outline",
         "//utils/ddc:expect_stable_js",
         "//utils/ddc:js_stable_js",
@@ -179,9 +179,9 @@ cc_library(
     ],
 )
 
-cc_library(
+filegroup(
     name = "ddc_test_pkg_outline",
-    deps = [
+    srcs = [
         "//utils/ddc:expect_outline",
         "//utils/ddc:js_outline",
         "//utils/ddc:meta_outline",
@@ -189,40 +189,40 @@ cc_library(
 )
 
 # TODO(M3): genrule for expect_canary_ddc_js (gn type=action)
-cc_library(name = "expect_canary_ddc_js")
+filegroup(name = "expect_canary_ddc_js")
 
 # TODO(M3): genrule for expect_canary_js (gn type=action)
-cc_library(name = "expect_canary_js")
+filegroup(name = "expect_canary_js")
 
 # TODO(M3): genrule for expect_outline (gn type=action)
-cc_library(name = "expect_outline")
+filegroup(name = "expect_outline")
 
 # TODO(M3): genrule for expect_stable_js (gn type=action)
-cc_library(name = "expect_stable_js")
+filegroup(name = "expect_stable_js")
 
 # TODO(M3): genrule for js_canary_ddc_js (gn type=action)
-cc_library(name = "js_canary_ddc_js")
+filegroup(name = "js_canary_ddc_js")
 
 # TODO(M3): genrule for js_canary_js (gn type=action)
-cc_library(name = "js_canary_js")
+filegroup(name = "js_canary_js")
 
 # TODO(M3): genrule for js_outline (gn type=action)
-cc_library(name = "js_outline")
+filegroup(name = "js_outline")
 
 # TODO(M3): genrule for js_stable_js (gn type=action)
-cc_library(name = "js_stable_js")
+filegroup(name = "js_stable_js")
 
 # TODO(M3): genrule for meta_canary_ddc_js (gn type=action)
-cc_library(name = "meta_canary_ddc_js")
+filegroup(name = "meta_canary_ddc_js")
 
 # TODO(M3): genrule for meta_canary_js (gn type=action)
-cc_library(name = "meta_canary_js")
+filegroup(name = "meta_canary_js")
 
 # TODO(M3): genrule for meta_outline (gn type=action)
-cc_library(name = "meta_outline")
+filegroup(name = "meta_outline")
 
 # TODO(M3): genrule for meta_stable_js (gn type=action)
-cc_library(name = "meta_stable_js")
+filegroup(name = "meta_stable_js")
 
 # rules_dart: compile stack_trace_mapper JS utility using prebuilt dart compile js.
 # Ports utils/ddc/BUILD.gn:dart2js_compile("stack_trace_mapper").


### PR DESCRIPTION
- Removed deleted 'out_of_band/' directory references from exports_files glob in tools/bazel/BUILD.bazel.
- Ignored upstream checkout directories under third_party/ in .bazelignore (boringssl/src, perfetto/src, cpu_features/src, emsdk/bazel, icu/source).
- Converted generic stub/wrapper cc_library targets to filegroup targets in root BUILD.bazel and utils/ddc/BUILD.bazel.
- Resolved DevTools build output path conflict by adding a copy_directory rule to tools/bazel/dart/defs.bzl, writing built/prebuilt artifacts to unique subdirectories, and copying the selected variant to the final path.
- Updated backlog (TASK_035) and status log.

Change-Id: I2fe46ac6387727a844f606f69f23c131526ae41f
