### PR TITLE
fix(convert): stop empty JSON key matching keys over 8 bytes

### DIFF
--- a/sdk/lib/convert/json_utf8.dart
+++ b/sdk/lib/convert/json_utf8.dart
@@ -103,7 +103,10 @@ final class JsonKeyOptions {
       builder.add(encoded);
 
       if (shortKeyInts != null && shortKeyLens != null && len <= 8) {
-        shortKeyLens[i] = len;
+        // Biased by 1 so that 0 is reserved for "not a short key". Without the
+        // bias, keys longer than 8 bytes keep the zero-filled default (0, 0),
+        // which is exactly what a lookup of the empty key computes.
+        shortKeyLens[i] = len + 1;
         var packed = 0;
         for (var j = 0; j < len; j++) {
           packed |= encoded[j] << (j * 8);
@@ -170,8 +173,9 @@ final class JsonKeyOptions {
     final lens = _shortKeyLens;
     if (ints == null || lens == null) return -1;
     final count = keys.length;
+    final biasedLen = len + 1;
     for (var i = 0; i < count; i++) {
-      if (lens[i] == len && ints[i] == keyInt) {
+      if (lens[i] == biasedLen && ints[i] == keyInt) {
         return i;
       }
     }

--- a/tests/lib/convert/json_utf8_swar_keys_test.dart
+++ b/tests/lib/convert/json_utf8_swar_keys_test.dart
@@ -20,6 +20,8 @@ void main() {
   testMatchKeyDirectSpanParsing();
   testDuplicateKeysPreserveFirst();
   testEmptyKeyHandling();
+  testEmptyKeyWithLongKeysPresent();
+  testEmptyKeyNotInOptions();
 }
 
 Uint8List _b(String s) => Uint8List.fromList(utf8.encode(s));
@@ -328,4 +330,43 @@ void testEmptyKeyHandling() {
   Expect.equals(1, reader.selectName(options));
   Expect.equals(20, reader.readInt());
   reader.endObject();
+}
+
+/// Keys longer than 8 UTF-8 bytes have no entry in the short-key tables. The
+/// empty key must not be confused with one of them, and must still be found
+/// when it is not the first entry.
+void testEmptyKeyWithLongKeysPresent() {
+  final options = JsonKeyOptions.of(['description', '', 'id']);
+  final reader = JsonTokenReader.fromBytes(_b('{"": 1, "id": 2}'));
+
+  reader.beginObject();
+  Expect.equals(1, reader.selectName(options));
+  Expect.equals(1, reader.readInt());
+  Expect.equals(2, reader.selectName(options));
+  Expect.equals(2, reader.readInt());
+  reader.endObject();
+
+  // The same span through the direct entry point.
+  final bytes = _b('{"": 1}');
+  Expect.equals(1, JsonUtf8Decoder.matchKey(bytes, 2, 2, options));
+}
+
+/// An empty key or string value that is absent from the options must report a
+/// miss, not the first key too long to be short-key encoded.
+void testEmptyKeyNotInOptions() {
+  final names = JsonKeyOptions.of(['description', 'id']);
+  final reader = JsonTokenReader.fromBytes(_b('{"": 1, "id": 2}'));
+  reader.beginObject();
+  Expect.equals(-1, reader.selectName(names));
+  reader.skipValue();
+  Expect.equals(1, reader.selectName(names));
+  Expect.equals(2, reader.readInt());
+  reader.endObject();
+
+  // selectString is the enum-dispatch path and must miss the same way.
+  final values = JsonKeyOptions.of(['admin', 'editor', 'pending_review']);
+  final r2 = JsonTokenReader.fromBytes(_b('{"role": "", "note": "x"}'));
+  r2.beginObject();
+  Expect.equals('role', r2.nextName());
+  Expect.equals(-1, r2.selectString(values));
 }


### PR DESCRIPTION
`JsonKeyOptions.of` only populates the SWAR short-key tables for keys of
8 UTF-8 bytes or fewer, so every longer key keeps the zero-filled default
pair `(len: 0, packed: 0)`. A lookup of the empty key computes exactly
that pair, and the SWAR path does no full-byte re-verification, so
`selectName`/`selectString`/`matchKey` silently return the first
over-length key instead of reporting a miss.

Empty string values are common and `selectString` is the enum-dispatch
entry point, so this is silent semantic corruption rather than a crash.
The hash path (`selectKey`) was unaffected.

Bias the stored length by one so that 0 is reserved for "not a short
key". This keeps the comparison a single integer test and leaves the
packed-bytes table untouched.

The existing `testEmptyKeyHandling` could not observe the bug: no key in
it exceeds 8 bytes, so the colliding slots never existed. Add coverage
for an empty key ordered after a long key, and for an empty key absent
from the options.

Affects the VM and dart2wasm; dart2js/DDC leave the SWAR tables null and
were already correct.
