### PR TITLE
fix(convert): make unsigned 64-bit compares correct on the web

### DIFF
--- a/sdk/lib/convert/json_utf8.dart
+++ b/sdk/lib/convert/json_utf8.dart
@@ -5661,13 +5661,25 @@ final Int32List _power10_Exp = Int32List.fromList(const <int>[
   1024, // q = 308
 ]);
 
-@pragma('vm:prefer-inline')
-bool _unsignedLe(int a, int b) =>
-    (a ^ 0x8000000000000000) <= (b ^ 0x8000000000000000);
+// Unsigned 64-bit comparisons.
+//
+// On the VM and Wasm `int` is a signed 64-bit integer, so a mantissa that has
+// wrapped past 2^63 compares as negative; flipping the sign bit restores
+// unsigned ordering. On the web `int` is a double and bitwise operators are
+// evaluated with 32-bit semantics: `x ^ 0x8000000000000000` truncates its
+// operands to 32 bits and yields `ToUint32(x)`, so the sign trick silently
+// compares the low 32 bits of each side. Web values reaching these helpers are
+// non-negative doubles, so a plain comparison is both correct and exact there.
 
 @pragma('vm:prefer-inline')
-bool _unsignedLt(int a, int b) =>
-    (a ^ 0x8000000000000000) < (b ^ 0x8000000000000000);
+bool _unsignedLe(int a, int b) => identical(1, 1.0)
+    ? a <= b
+    : (a ^ 0x8000000000000000) <= (b ^ 0x8000000000000000);
+
+@pragma('vm:prefer-inline')
+bool _unsignedLt(int a, int b) => identical(1, 1.0)
+    ? a < b
+    : (a ^ 0x8000000000000000) < (b ^ 0x8000000000000000);
 
 @pragma('vm:prefer-inline')
 int _clz64(int w) {

--- a/tests/lib/convert/json_utf8_web_integers_test.dart
+++ b/tests/lib/convert/json_utf8_web_integers_test.dart
@@ -12,7 +12,43 @@ void main() {
   testJsonTokenWriterLargeIntegers();
   testWriteIntToBufferLargeIntegers();
   testDecodeLargeIntegersPrecision();
+  testDecodeCorrectlyRoundedLargeIntegers();
   testTokenReaderLargeIntegers();
+}
+
+/// Values that reach the decoder's unsigned 64-bit range checks.
+///
+/// On the web `int` is a double and bitwise operators are evaluated with
+/// 32-bit semantics, so an `x ^ 0x8000000000000000` sign-flip comparison
+/// silently degenerates to comparing the low 32 bits. When that check is wrong
+/// the digit-accumulation shortcut is taken for values it cannot represent and
+/// the result is off by one or more ulp from the correctly rounded value that
+/// `json.decode` produces.
+void testDecodeCorrectlyRoundedLargeIntegers() {
+  const cases = [
+    "9308364126768071717",
+    "9095156293722702342",
+    "8925238349618745892",
+    "68323050187018705",
+    "999999999999999999",
+    "1234567890123456789",
+    "9999999999999999999", // > int64 max: decoded as a double
+    "9223372036854775807", // int64 max
+  ];
+
+  for (final s in cases) {
+    final bytes = Uint8List.fromList(utf8.encode(s));
+    Expect.equals(
+      json.decode(s),
+      jsonUtf8.decode(bytes),
+      'Not correctly rounded: "$s"',
+    );
+    Expect.equals(
+      double.parse(s),
+      JsonUtf8Decoder.parseDouble(bytes, 0, bytes.length),
+      'parseDouble not correctly rounded: "$s"',
+    );
+  }
 }
 
 /// Verifies that jsonUtf8.encode on numbers >= 20 digits does not corrupt


### PR DESCRIPTION
`_unsignedLe`/`_unsignedLt` flip the sign bit with
`x ^ 0x8000000000000000` to get unsigned ordering out of signed int64.
On dart2js and DDC `int` is a double and bitwise operators are evaluated
with 32-bit semantics: the constant truncates to 0 and both sides
collapse to `ToUint32(x)`, so the comparison comes out arbitrary.

`_tryParseDoubleUtf8` and `_JsonTokenReader.readDouble` use `_unsignedLe`
to keep the exponent-zero integer shortcut below 2^53, where digit
accumulation is exact. With the check broken the shortcut is taken for
values it cannot represent and the accumulated mantissa is returned
instead of a correctly rounded double, so `jsonUtf8.decode` disagrees
with `json.decode` on the same bytes.

Compare directly on the web, where the values reaching these helpers are
non-negative doubles and `<=` is both correct and exact, and keep the
sign-flip on the VM and Wasm.

Verified with a differential run against `json.decode`/`double.parse` on
the VM and under dart2js at -O0, -O2 and -O4. Before: 11 mismatches at
-O0 and 2 at -O2/-O4. After: none at any level. The -O2 result matters
because the old code only appeared correct there by accident -- the
optimizer constant-folds the sign-flip to 0, which happens to force the
guard false; DDC does not inline it and drifted at every value.
