### PR TITLE
fix(convert): keep web integer formatting exact above 2^53

### DIFF
--- a/sdk/lib/convert/json_utf8.dart
+++ b/sdk/lib/convert/json_utf8.dart
@@ -847,7 +847,9 @@ final class JsonUtf8Encoder extends Converter<Object?, List<int>> {
 
   /// Formats [value] as an ASCII integer literal directly into [sink].
   static void writeInt(int value, BytesBuilder sink) {
-    if (value >= 1e19 || value <= -1e19) {
+    // See [writeIntToBuffer] for why the limit is platform dependent.
+    final limit = identical(1, 1.0) ? 9007199254740992.0 : 1e19;
+    if (value >= limit || value <= -limit) {
       final str = value.toString();
       for (var i = 0; i < str.length; i++) {
         sink.addByte(str.codeUnitAt(i));
@@ -876,7 +878,14 @@ final class JsonUtf8Encoder extends Converter<Object?, List<int>> {
       buffer[offset] = 48; // '0'
       return 1;
     }
-    if (value >= 1e19 || value <= -1e19) {
+    // Above this magnitude the value is formatted with `toString` instead of
+    // the `_digitPairs` loop. On the VM and Wasm `int` is a signed 64-bit
+    // integer and the loop is exact across the whole range, so the limit sits
+    // above it. On the web `int` is a double: `~/` and `*` stop being exact
+    // past 2^53, so `next * 100` can overshoot `temp`, which drives the
+    // remainder negative and indexes outside `_digitPairs`.
+    final limit = identical(1, 1.0) ? 9007199254740992.0 : 1e19;
+    if (value >= limit || value <= -limit) {
       final str = value.toString();
       final len = str.length;
       if (offset < 0 || offset + len > buffer.length) {

--- a/tests/lib/convert/json_utf8_web_integers_test.dart
+++ b/tests/lib/convert/json_utf8_web_integers_test.dart
@@ -12,7 +12,64 @@ void main() {
   testJsonTokenWriterLargeIntegers();
   testWriteIntToBufferLargeIntegers();
   testDecodeLargeIntegersPrecision();
+  testEncodeIntegersAbove2Pow53();
   testTokenReaderLargeIntegers();
+}
+
+/// Integers between 2^53 and 1e19 are ordinary `int` values on every platform,
+/// but on the web `int` is a double, so `~/` and `*` in the digit-pair
+/// formatter stop being exact. An overshooting quotient drives the pair
+/// remainder negative, which either indexes outside the digit table or emits
+/// well-formed but wrong digits.
+void testEncodeIntegersAbove2Pow53() {
+  final values = <int>[
+    9007199254740991, // 2^53 - 1, last exact value
+    9007199254740992, // 2^53
+    60592972518337896,
+    42845701759940776,
+    68323050187018704,
+    1000000000000000000, // 1e18
+    4611686018427387904, // 2^62
+  ];
+
+  // A deterministic sweep of the binades in between.
+  var seed = 0x51ed270b;
+  var power = 9007199254740992; // 2^53
+  for (var binade = 0; binade < 9; binade++) {
+    for (var i = 0; i < 40; i++) {
+      seed = (seed * 1103515245 + 12345) & 0x3FFFFFFF;
+      values.add(power + (seed % 1000) * 97);
+    }
+    power *= 2;
+  }
+
+  final buffer = Uint8List(64);
+  for (final magnitude in values) {
+    for (final value in [magnitude, -magnitude]) {
+      final expected = value.toString();
+
+      final written = JsonUtf8Encoder.writeIntToBuffer(value, buffer, 4);
+      Expect.equals(
+        expected,
+        utf8.decode(Uint8List.sublistView(buffer, 4, 4 + written)),
+        'writeIntToBuffer disagrees with toString for $value',
+      );
+
+      final sink = BytesBuilder(copy: false);
+      JsonUtf8Encoder.writeInt(value, sink);
+      Expect.equals(
+        expected,
+        utf8.decode(sink.takeBytes()),
+        'writeInt disagrees with toString for $value',
+      );
+
+      Expect.equals(
+        json.encode(value),
+        utf8.decode(jsonUtf8.encode(value)),
+        'jsonUtf8.encode disagrees with json.encode for $value',
+      );
+    }
+  }
 }
 
 /// Verifies that jsonUtf8.encode on numbers >= 20 digits does not corrupt


### PR DESCRIPTION
The digit-pair formatter falls back to `toString` at 1e19, but on the web
it stops being correct far earlier. There `int` is a double, so once the
value exceeds 2^53 `temp ~/ 100` is inexact and `next * 100` can overshoot
`temp`. The pair remainder then goes negative, and because `<<` is a
32-bit operation on the web the index becomes roughly 4.29e9: either an
IndexError out of `_digitPairs`, or -- when the overshoot is small enough
to stay in range -- well-formed but wrong digits.

Lower the fallback threshold to 2^53 on the web and leave it at 1e19 on
the VM and Wasm, where `int` is a signed 64-bit integer and the loop is
exact across the entire range. The VM keeps the fast path for every value
it can represent.

Fuzzing `writeIntToBuffer` and `writeInt` over the 2^53..2^62 binades
(20,028 cases) under dart2js: 9,748 wrong results and 4 thrown
IndexErrors before, none after. The VM was unaffected in both directions.

Round-trips were lossy in this range: decoding 68323050187018705 and
re-encoding produced a literal that parsed back to a different double.
