### PR TITLE
fix(convert): stop oversized exponents folding back into range

### DIFF
--- a/sdk/lib/convert/json_utf8.dart
+++ b/sdk/lib/convert/json_utf8.dart
@@ -2401,13 +2401,24 @@ final class _JsonTokenReader implements JsonTokenReader {
         throw FormatException('Expected digit in exponent', _bytes, i);
       }
       var explicitExp = 0;
+      var expSaturated = false;
       while (i < _bytes.length && _bytes[i] >= 48 && _bytes[i] <= 57) {
         if (explicitExp < 10000) {
           explicitExp = explicitExp * 10 + (_bytes[i] - 48);
+        } else {
+          expSaturated = true;
         }
         i++;
       }
       decimalExp += expNeg ? -explicitExp : explicitExp;
+      if (expSaturated) {
+        // The exponent has more digits than can matter. Dropping them lets the
+        // mantissa digit count cancel the truncated value back into the
+        // Eisel-Lemire window, which turns an underflow or overflow into a
+        // confident finite result. Pin it outside the window instead so the
+        // platform parser produces the 0 or Infinity.
+        decimalExp = expNeg ? -100000 : 100000;
+      }
     }
 
     // Delimiter check: next byte must be EOF, ',', '}', ']', or whitespace
@@ -5905,13 +5916,22 @@ double? _tryParseDoubleUtf8(
       return null;
     }
     var explicitExp = 0;
+    var expSaturated = false;
     while (i < actualEnd && source[i] >= 48 && source[i] <= 57) {
       if (explicitExp < 10000) {
         explicitExp = explicitExp * 10 + (source[i] - 48);
+      } else {
+        expSaturated = true;
       }
       i++;
     }
     decimalExp += expNegative ? -explicitExp : explicitExp;
+    if (expSaturated) {
+      // See the matching note in _JsonTokenReader.readDouble: a truncated
+      // exponent can be cancelled back into range by the mantissa digit
+      // count, so pin it outside the Eisel-Lemire window instead.
+      decimalExp = expNegative ? -100000 : 100000;
+    }
   }
 
   if (i != actualEnd) return null;

--- a/tests/lib/convert/json_utf8_eisel_lemire_test.dart
+++ b/tests/lib/convert/json_utf8_eisel_lemire_test.dart
@@ -14,7 +14,49 @@ void main() {
   testNegativeRfc8259Syntax();
   testTokenReaderReadDouble();
   testTokenReaderAtomicRollback();
+  testOversizedExponents();
   testFuzzDifferential100k();
+}
+
+/// Exponents with more digits than the scanner's accumulator can hold.
+///
+/// Truncating the accumulator is not safe: the decimal exponent is also
+/// adjusted by the mantissa's digit count, so a truncated exponent can be
+/// cancelled back into the Eisel-Lemire table window and yield a confident
+/// finite result for a value that underflows to zero or overflows to infinity.
+void testOversizedExponents() {
+  final manyDigits = ("123456789" * 1114).substring(0, 10019);
+  final manyZeros = "0" * 10000;
+
+  final cases = <String>[
+    "${manyDigits}e-100000",
+    "-${manyDigits}e-100000",
+    "0.${manyZeros}1e100000",
+    "1e100000",
+    "1e-100000",
+    "1e999999999",
+    "1e-999999999",
+    "1e309",
+    "1e-400",
+  ];
+
+  for (final source in cases) {
+    final bytes = _utf8Bytes(source);
+    final expected = double.parse(source);
+    final actual = JsonUtf8Decoder.parseDouble(bytes, 0, bytes.length);
+    final label = source.length > 32
+        ? "${source.substring(0, 16)}...(${source.length} chars)"
+        : source;
+    Expect.equals(expected, actual, 'parseDouble("$label")');
+    Expect.equals(
+      expected.isNegative,
+      actual.isNegative,
+      'sign of parseDouble("$label")',
+    );
+
+    final reader = JsonTokenReader.fromBytes(bytes);
+    Expect.equals(expected, reader.readDouble(), 'readDouble("$label")');
+  }
 }
 
 extension DoubleBits on double {


### PR DESCRIPTION
Both decimal scanners cap the explicit-exponent accumulator at 10000 and
then silently discard the remaining digits. The decimal exponent is also
adjusted by the mantissa's truncated integer digits and by fractional
leading zeros, so a discarded exponent can be cancelled by the digit
count and land back inside the Eisel-Lemire table window. The parser then
returns a confident finite double for a value that is really 0 or
Infinity.

Pin the exponent outside the window when the accumulator saturates,
after the digit-count adjustment has been applied, so no cancellation is
possible and the platform parser produces the correct result.

Affects the VM, Wasm and the web equally: the bug is in the scanner, not
in the 64-bit arithmetic. The inputs are well-formed JSON and fully
attacker-controllable at around 10 KB.

  "123...789e-100000"  (10019 mantissa digits)
      was 1234567891234568000.0, want 0.0
  "0.000...1e100000"   (10000 fractional zeros)
      was 0.1, want Infinity

Both scanners are fixed and covered, via parseDouble and readDouble.
