### PR TITLE
fix(convert): reject a non-positive JsonUtf8Encoder bufferSize

### DIFF
--- a/sdk/lib/convert/json_utf8.dart
+++ b/sdk/lib/convert/json_utf8.dart
@@ -711,14 +711,28 @@ final class JsonUtf8Encoder extends Converter<Object?, List<int>> {
   /// The [toEncodable] function is called on objects that are not natively encodable.
   ///
   /// The [bufferSize] specifies the chunk buffer size (in bytes) used during
-  /// chunked conversion. If omitted, defaults to 32 KB (32768 bytes).
+  /// chunked conversion. It must be greater than zero. If omitted, defaults to
+  /// 32 KB (32768 bytes).
+  ///
+  /// Throws a [RangeError] if [bufferSize] is zero or negative.
   JsonUtf8Encoder([
     String? indent,
     dynamic Function(dynamic object)? toEncodable,
     int? bufferSize,
   ]) : _indent = _utf8Encode(indent),
        _toEncodable = toEncodable,
-       _bufferSize = bufferSize ?? _defaultBufferSize;
+       _bufferSize = _checkBufferSize(bufferSize);
+
+  static int _checkBufferSize(int? bufferSize) {
+    if (bufferSize == null) return _defaultBufferSize;
+    // The copy loops flush and retry whenever the buffer is full. With a
+    // zero-length buffer the flush cannot free any space, so the retry would
+    // spin forever.
+    if (bufferSize < 1) {
+      throw RangeError.value(bufferSize, 'bufferSize', 'Must be positive');
+    }
+    return bufferSize;
+  }
 
   static List<int>? _utf8Encode(String? string) {
     if (string == null) return null;

--- a/tests/lib/convert/json_utf8_chunked_streaming_test.dart
+++ b/tests/lib/convert/json_utf8_chunked_streaming_test.dart
@@ -14,6 +14,39 @@ void main() {
   testChunkedLargeDocumentStreaming();
   testEncoderConvertSmallBufferSize();
   testMicroBufferSizeChunkedStreaming();
+  testNonPositiveBufferSizeRejected();
+}
+
+/// A zero or negative buffer size cannot be honoured: the copy loops flush and
+/// retry whenever the buffer is full, and a zero-length buffer never frees any
+/// space, so the retry spins forever. Reject it at construction instead.
+void testNonPositiveBufferSizeRejected() {
+  for (final bufferSize in [0, -1, -32768]) {
+    Expect.throwsRangeError(
+      () => JsonUtf8Encoder(null, null, bufferSize),
+      'bufferSize $bufferSize should be rejected',
+    );
+    Expect.throwsRangeError(
+      () => JsonUtf8Codec(bufferSize: bufferSize).encoder,
+      'JsonUtf8Codec bufferSize $bufferSize should be rejected',
+    );
+  }
+
+  // The smallest legal size still encodes correctly.
+  final value = {
+    'a': 'hello world',
+    'b': [1, 2.5, true, null],
+  };
+  Expect.equals(
+    json.encode(value),
+    utf8.decode(JsonUtf8Encoder(null, null, 1).convert(value)),
+  );
+
+  // Omitting the size keeps the default.
+  Expect.equals(
+    json.encode(value),
+    utf8.decode(JsonUtf8Encoder().convert(value)),
+  );
 }
 
 final class _ChunkCapturingSink extends ByteConversionSink {


### PR DESCRIPTION
The chunked copy loops compute the free space as
`buffer.length - index`, and when it reaches zero they call
`_flushBuffer()` and retry. `_flushBuffer` emits whatever is pending and
reallocates `Uint8List(bufferSize)`, so with a buffer size of zero the
free space is zero again on every iteration and the loop cannot
terminate.

`JsonUtf8Encoder` validated nothing, so `JsonUtf8Encoder(null, null, 0)`
hung on any non-empty output. Upstream threw a RangeError here, and a
hang is worse than either the old behaviour or an error.

Validate in the constructor so the failure is immediate and describes
itself. `JsonUtf8Codec` routes through the same constructor via its
`encoder` getter and is covered too.
