### PR TITLE
perf(convert): bound writeString scratch and drain it in one copy

### DIFF
--- a/sdk/lib/convert/json_utf8.dart
+++ b/sdk/lib/convert/json_utf8.dart
@@ -795,12 +795,24 @@ final class JsonUtf8Encoder extends Converter<Object?, List<int>> {
 
   /// Writes [value] with standard JSON escaping directly into [sink].
   static void writeString(String value, BytesBuilder sink) {
-    final maxLen = value.length * 6 + 2;
-    final buf = Uint8List(maxLen <= 256 ? 256 : maxLen);
-    final len = writeStringToBuffer(value, buf, 0);
-    for (var i = 0; i < len; i++) {
-      sink.addByte(buf[i]);
+    // Six bytes per code unit is only reached by a string made entirely of
+    // control characters or isolated surrogates. Three covers every
+    // unescaped code unit, including astral characters, which arrive as a
+    // surrogate pair and encode to four bytes across two units. Sizing for
+    // the worst case up front costs twice the output for ordinary text and,
+    // with no floor, allocated 256 bytes for every short object key.
+    final length = value.length;
+    var buffer = Uint8List(length * 3 + 2);
+    int written;
+    try {
+      written = writeStringToBuffer(value, buffer, 0);
+    } on RangeError {
+      // Escape-heavy: retry once at the true worst case. The offset is zero
+      // and the buffer is local, so capacity is the only possible cause.
+      buffer = Uint8List(length * 6 + 2);
+      written = writeStringToBuffer(value, buffer, 0);
     }
+    sink.add(Uint8List.sublistView(buffer, 0, written));
   }
 
   /// Writes [value] with standard JSON escaping directly into [buffer] starting

--- a/tests/lib/convert/json_utf8_span_parsers_test.dart
+++ b/tests/lib/convert/json_utf8_span_parsers_test.dart
@@ -18,6 +18,7 @@ void main() {
   testIsVerbatim();
   testSkipMethods();
   testEncoderBufferWriters();
+  testWriteStringEscapeDensities();
   testSurrogateEncoding();
   testRfc8259NumberGrammar();
   testIntegerOverflowAndLimits();
@@ -475,6 +476,57 @@ void testEncoderBufferWriters() {
     isFirst: false,
   );
   Expect.equals(r',"k\\":', utf8.decode(buffer.sublist(0, len)));
+}
+
+/// [JsonUtf8Encoder.writeString] sizes its scratch buffer for the common case
+/// of three bytes per code unit and re-sizes to the six-byte worst case only
+/// when the string is escape heavy. Both paths must produce identical output,
+/// so exercise strings on either side of that boundary.
+void testWriteStringEscapeDensities() {
+  String encode(String value) {
+    final sink = BytesBuilder(copy: false);
+    JsonUtf8Encoder.writeString(value, sink);
+    return utf8.decode(sink.takeBytes());
+  }
+
+  final samples = <String>[
+    "",
+    "a",
+    "id",
+    "plain ascii text",
+    "café €",
+    "中文测试", // 3 bytes per code unit
+    "\u{1F680}\u{1F600}", // surrogate pairs, 4 bytes per pair
+    '"', "\\", "\b\f\n\r\t",
+    "\u0000\u0001\u001f", // 6 bytes per code unit: forces the re-size
+    "mix \u0001 \"q\" \u{1F680} 中",
+    "\u0001" * 1000, // wholly escape heavy
+    "a" * 1000,
+    "中" * 1000,
+    "\u{1F680}" * 500,
+    String.fromCharCode(0xD800), // isolated high surrogate
+    String.fromCharCode(0xDC00), // isolated low surrogate
+    "before${String.fromCharCode(0xD800)}after",
+  ];
+
+  for (final value in samples) {
+    final actual = encode(value);
+    Expect.equals(json.encode(value), actual, 'writeString("${value.length}")');
+
+    // The token writer routes its string and name output through the same
+    // helper, so it must agree byte for byte.
+    final sink = BytesBuilder(copy: false);
+    JsonTokenWriter.toSink(sink)
+      ..beginObject()
+      ..writeName("k")
+      ..writeString(value)
+      ..endObject();
+    Expect.equals(
+      json.encode({"k": value}),
+      utf8.decode(sink.takeBytes()),
+      'JsonTokenWriter round trip for a ${value.length} code unit string',
+    );
+  }
 }
 
 void testSurrogateEncoding() {


### PR DESCRIPTION
Routing JsonTokenWriter through the native string encoder replaced a
zero-allocation streaming encoder with a per-call scratch buffer sized at
`value.length * 6 + 2` and floored at 256 bytes, drained one byte at a
time through `addByte`. Encoding an object with many short keys allocated
256 bytes per key where it previously allocated none, and the byte-wise
drain gave back most of the throughput the native call was meant to buy.

Six bytes per code unit is only reached by a string made entirely of
control characters or isolated surrogates. Size for three, which covers
every unescaped code unit including astral characters -- they arrive as a
surrogate pair, so four bytes span two units -- and re-size once for the
escape-heavy case. Drop the 256-byte floor so a short key allocates for a
short key, and hand the result to the sink with a single `add` of a
sublist view.

Output is unchanged: 4,018 samples spanning ASCII, Latin-1, CJK, astral
pairs, isolated surrogates, every escape class and both sides of the
re-size boundary produce byte-identical results on the VM and dart2js,
through both `writeString` and `JsonTokenWriter`.

  200k short keys     165 ms -> 30 ms
  20 MB ASCII string 1154 ms -> 34 ms, peak scratch 114 MB -> 57 MB

This bounds the constant factor but not the growth: the helper still
buffers the whole string before handing it over, because
`writeStringToBuffer` emits the surrounding quotes and so cannot be
called per segment. Streaming it needs a content-only escaping primitive,
which is left for a separate change.
