### PR TITLE
fix(convert): reject a non-positive JsonTokenWriter capacity

### DIFF
--- a/sdk/lib/convert/json_utf8.dart
+++ b/sdk/lib/convert/json_utf8.dart
@@ -2718,6 +2718,11 @@ abstract interface class JsonTokenWriter {
   factory JsonTokenWriter.toSink(BytesBuilder sink) = _JsonTokenWriter;
 
   /// Instantiates a contiguous buffer token writer with [initialCapacity].
+  ///
+  /// The buffer grows as needed, so [initialCapacity] only affects how often
+  /// that happens. It must be greater than zero.
+  ///
+  /// Throws a [RangeError] if [initialCapacity] is zero or negative.
   factory JsonTokenWriter.toBuffer([int initialCapacity]) =
       _BufferJsonTokenWriter;
 
@@ -2953,7 +2958,21 @@ final class _BufferJsonTokenWriter implements JsonTokenWriter {
   bool _hasRootValue = false;
 
   _BufferJsonTokenWriter([int initialCapacity = 256])
-    : _buffer = Uint8List(initialCapacity > 0 ? initialCapacity : 256);
+    : _buffer = Uint8List(_checkCapacity(initialCapacity));
+
+  static int _checkCapacity(int initialCapacity) {
+    // Silently substituting a default hides a caller that computed its
+    // capacity from a bad size hint. JsonUtf8Encoder rejects a non-positive
+    // bufferSize for the same reason.
+    if (initialCapacity < 1) {
+      throw RangeError.value(
+        initialCapacity,
+        'initialCapacity',
+        'Must be positive',
+      );
+    }
+    return initialCapacity;
+  }
 
   @pragma('vm:prefer-inline')
   @pragma('wasm:prefer-inline')

--- a/tests/lib/convert/json_token_writer_buffer_test.dart
+++ b/tests/lib/convert/json_token_writer_buffer_test.dart
@@ -14,6 +14,33 @@ void main() {
   testBufferWriterNamesAndKeys();
   testBufferWriterStateMachineAndErrors();
   testBothWritersParity();
+  testBufferWriterRejectsNonPositiveCapacity();
+}
+
+/// A non-positive initial capacity is a caller mistake, usually a size hint
+/// that computed to zero, and is reported rather than silently replaced with
+/// the default. [JsonUtf8Encoder] rejects its `bufferSize` the same way.
+void testBufferWriterRejectsNonPositiveCapacity() {
+  for (final capacity in [0, -1, -1000]) {
+    Expect.throwsRangeError(
+      () => JsonTokenWriter.toBuffer(capacity),
+      'initialCapacity $capacity should be rejected',
+    );
+  }
+
+  // The smallest legal capacity still encodes correctly, growing as needed.
+  final w = JsonTokenWriter.toBuffer(1);
+  w.beginArray();
+  w.writeInt(1);
+  w.writeString('two');
+  w.writeDouble(3.5);
+  w.endArray();
+  Expect.equals('[1,"two",3.5]', utf8.decode(w.toBytes()));
+
+  // Omitting the capacity keeps the default.
+  final d = JsonTokenWriter.toBuffer();
+  d.writeInt(7);
+  Expect.equals('7', utf8.decode(d.toBytes()));
 }
 
 void testBufferWriterPrimitives() {


### PR DESCRIPTION
`_BufferJsonTokenWriter` substituted the default for any `initialCapacity`
that was not positive, so `JsonTokenWriter.toBuffer(0)` and negative
capacities constructed successfully and a caller whose size hint computed
to zero never found out.

Throw a RangeError instead, matching the treatment `JsonUtf8Encoder` gives
its `bufferSize`, and document the constraint on the factory.

The buffer grows on demand, so a capacity of 1 remains valid and is
covered, as is omitting the argument.
