### PR TITLE
fix(convert): give JsonTokenWriter.toBytes one aliasing contract

### DIFF
--- a/sdk/lib/convert/json_utf8.dart
+++ b/sdk/lib/convert/json_utf8.dart
@@ -2735,7 +2735,15 @@ abstract interface class JsonTokenWriter {
   void writeBool(bool value);
   void writeNull();
 
-  /// Returns the encoded UTF-8 JSON bytes.
+  /// Returns a copy of the UTF-8 JSON bytes written so far.
+  ///
+  /// The copy belongs to the caller and is independent of this writer in both
+  /// directions: writing more does not change bytes already returned, and
+  /// modifying the returned list does not disturb the writer, which stays
+  /// usable.
+  ///
+  /// Calling this before the document is complete returns the partial output;
+  /// closing every container is the caller's responsibility.
   Uint8List toBytes();
 }
 
@@ -3196,7 +3204,8 @@ final class _BufferJsonTokenWriter implements JsonTokenWriter {
   }
 
   @override
-  Uint8List toBytes() => Uint8List.sublistView(_buffer, 0, _cursor);
+  Uint8List toBytes() =>
+      Uint8List.fromList(Uint8List.sublistView(_buffer, 0, _cursor));
 }
 
 // =============================================================================

--- a/tests/lib/convert/json_token_writer_buffer_test.dart
+++ b/tests/lib/convert/json_token_writer_buffer_test.dart
@@ -141,8 +141,70 @@ void testBufferWriterToBytesView() {
   Expect.equals(5, bytes.length); // "[1,2]" is 5 bytes
   Expect.equals("[1,2]", utf8.decode(bytes));
 
-  // Verify toBytes() returns Uint8List sublistView
-  Expect.isTrue(bytes is Uint8List);
+  testToBytesIsIndependentOfTheWriter();
+}
+
+/// [JsonTokenWriter.toBytes] hands the caller a copy that is independent of
+/// the writer in both directions. Both writer flavours have to agree, since
+/// callers only ever see the interface.
+void testToBytesIsIndependentOfTheWriter() {
+  for (final make in [
+    () => JsonTokenWriter.toBuffer(1024), // room to spare: no growth
+    () => JsonTokenWriter.toBuffer(1), // grows on every write
+    () => JsonTokenWriter.toBuffer(16), // grows partway through
+    () => JsonTokenWriter.toSink(BytesBuilder()),
+  ]) {
+    final w = make();
+    w.beginArray();
+    w.writeInt(1);
+    final snapshot = w.toBytes();
+    final snapshotText = utf8.decode(snapshot);
+
+    // Continuing to write must not disturb the snapshot.
+    w.writeInt(2);
+    w.writeString("three");
+    w.endArray();
+    Expect.equals(
+      snapshotText,
+      utf8.decode(snapshot),
+      'toBytes() result changed after further writes',
+    );
+
+    // ...and the completed document must still be correct.
+    Expect.equals('[1,2,"three"]', utf8.decode(w.toBytes()));
+  }
+
+  // Modifying the returned bytes must not reach back into the writer.
+  for (final make in [
+    () => JsonTokenWriter.toBuffer(1024),
+    () => JsonTokenWriter.toSink(BytesBuilder()),
+  ]) {
+    final w = make();
+    w.beginArray();
+    w.writeInt(1);
+    w.toBytes()[0] = 0x58; // 'X'
+    w.writeInt(2);
+    w.endArray();
+    Expect.equals(
+      '[1,2]',
+      utf8.decode(w.toBytes()),
+      'writing to the result of toBytes() corrupted the writer',
+    );
+  }
+
+  // Repeated snapshots stay valid alongside each other.
+  final w = JsonTokenWriter.toBuffer(1024);
+  w.beginObject();
+  w.writeName("a");
+  w.writeInt(1);
+  final first = w.toBytes();
+  w.writeName("b");
+  w.writeInt(2);
+  final second = w.toBytes();
+  w.endObject();
+  Expect.equals('{"a":1', utf8.decode(first));
+  Expect.equals('{"a":1,"b":2', utf8.decode(second));
+  Expect.equals('{"a":1,"b":2}', utf8.decode(w.toBytes()));
 }
 
 void testBufferWriterNamesAndKeys() {


### PR DESCRIPTION
`toBytes()` had two different meanings depending on the factory used.
`JsonTokenWriter.toSink` delegates to `BytesBuilder.toBytes`, documented as
"a copy of the current byte contents" that "leaves the contents of this
builder intact". `JsonTokenWriter.toBuffer` returned
`Uint8List.sublistView(_buffer, 0, _cursor)`, a live view of the writer's
own buffer. Callers see only the interface, so they cannot tell which they
have.

The view leaks in the caller-to-writer direction: writing into what looks
like your own byte array reaches back into the writer.

  final w = JsonTokenWriter.toBuffer(1024);
  w.beginArray(); w.writeInt(1);
  w.toBytes()[0] = 0x58;      // 'X'
  w.writeInt(2); w.endArray();
  w.toBytes();                // "X1,2]" instead of "[1,2]"

Return a copy from the buffer writer too, and document the guarantee on
the interface rather than on one implementation.

Appending was already safe in the other direction, since writes land at or
past the cursor, and the tests cover both directions anyway so neither can
regress. Also covers repeated snapshots, all three growth regimes, and both
writer flavours.

The old assertion here was `Expect.isTrue(bytes is Uint8List)`, which is
statically always true and passes whether toBytes copies or aliases.
