### PR TITLE
test(convert): make two passing assertions actually assert something

### DIFF
--- a/tests/lib/convert/json_token_writer_buffer_test.dart
+++ b/tests/lib/convert/json_token_writer_buffer_test.dart
@@ -281,4 +281,21 @@ void testBothWritersParity() {
   final bufferBytes = bufferWriter.toBytes();
 
   Expect.listEquals(sinkBytes, bufferBytes);
+
+  // Agreeing with each other is not enough: two writers sharing a formatting
+  // helper can agree on the same wrong bytes. Pin both to json.encode.
+  final expected = json.encode({
+    "alpha": 123456,
+    "beta": -42.75,
+    "gamma": false,
+    "delta": null,
+    "epsilon": "Unicode \u{1F680} \u0000 \t \n \"quote\"",
+    "nested": [
+      1,
+      2,
+      {"inner": "val"},
+    ],
+  });
+  Expect.equals(expected, utf8.decode(sinkBytes));
+  Expect.equals(expected, utf8.decode(bufferBytes));
 }

--- a/tests/lib/convert/json_utf8_swar_keys_test.dart
+++ b/tests/lib/convert/json_utf8_swar_keys_test.dart
@@ -397,10 +397,20 @@ void testStringCacheReadString() {
   Expect.equals('status', s3);
   Expect.equals('', empty);
 
-  // Check identity caching (hit returns exact same instance)
-  Expect.identical(s1, s2);
-  Expect.identical(s1, s3);
-  Expect.identical(a1, a2);
+  // Identity only says something where the cache exists. The cache packs
+  // eight key bytes into a 64-bit integer, so it is disabled on dart2js and
+  // DDC, where `int` is a double -- and there JavaScript reports equal strings
+  // as identical anyway, so asserting it unconditionally would pass without
+  // testing anything.
+  if (!identical(1, 1.0)) {
+    Expect.identical(s1, s2);
+    Expect.identical(s1, s3);
+    Expect.identical(a1, a2);
+
+    // Distinct values must not share an instance, so a passing run above
+    // cannot be explained by the reader returning one string for everything.
+    Expect.notIdentical(s1, a1);
+  }
 
   // 2. Empty string caching test
   final emptyStringsJson = '["", "", ""]';
@@ -411,8 +421,12 @@ void testStringCacheReadString() {
   final e3 = rEmpty.readString();
   rEmpty.endArray();
   Expect.equals('', e1);
-  Expect.identical(e1, e2);
-  Expect.identical(e1, e3);
+  Expect.equals('', e2);
+  Expect.equals('', e3);
+  if (!identical(1, 1.0)) {
+    Expect.identical(e1, e2);
+    Expect.identical(e1, e3);
+  }
 
   // 3. Collision handling: test 128 distinct short strings (more than the 64 cache slots)
   final keys = List.generate(128, (i) => 'k$i');


### PR DESCRIPTION
Neither changes library behaviour; each currently reports coverage it does
not have.

`testBothWritersParity` compared the sink writer against the buffer writer
and nothing else. Both route their string and number formatting through
the same helpers, so any shared formatting bug produces the same wrong
bytes on both sides and the comparison still succeeds. Pin both to
json.encode.

`testStringCacheReadString` asserted `Expect.identical` on decoded strings.
The cache packs eight bytes into a 64-bit integer and so is disabled on
dart2js and DDC, where `int` is a double -- and JavaScript reports equal
strings as identical regardless, so the assertion passed on the web
without the cache ever running. Scope it to platforms that have the cache,
keep plain equality everywhere, and add a notIdentical check so a reader
that returned one string for every value could not satisfy it.
