### PR TITLE
fix(convert): restore native fused utf8+json decode fast paths

### DIFF
--- a/sdk/lib/_internal/js_dev_runtime/patch/convert_patch.dart
+++ b/sdk/lib/_internal/js_dev_runtime/patch/convert_patch.dart
@@ -350,6 +350,17 @@ class _JsonMapKeyIterable extends ListIterable<String> {
 }
 
 @patch
+class JsonUtf8Decoder {
+  @patch
+  Object? convert(List<int> input) {
+    // Route through the platform-native string decoder and `JSON.parse`,
+    // which are far faster than the pure-Dart token reader on web.
+    final source = Utf8Decoder(allowMalformed: allowMalformed).convert(input);
+    return _parseJson(source, reviver);
+  }
+}
+
+@patch
 class JsonDecoder {
   @patch
   StringConversionSink startChunkedConversion(Sink<Object?> sink) {

--- a/sdk/lib/_internal/js_runtime/lib/convert_patch.dart
+++ b/sdk/lib/_internal/js_runtime/lib/convert_patch.dart
@@ -354,6 +354,17 @@ class _JsonMapKeyIterable extends ListIterable<String> {
 }
 
 @patch
+class JsonUtf8Decoder {
+  @patch
+  Object? convert(List<int> input) {
+    // Route through the platform-native string decoder and `JSON.parse`,
+    // which are far faster than the pure-Dart token reader on web.
+    final source = Utf8Decoder(allowMalformed: allowMalformed).convert(input);
+    return _parseJson(source, reviver);
+  }
+}
+
+@patch
 class JsonDecoder {
   @patch
   StringConversionSink startChunkedConversion(Sink<Object?> sink) {

--- a/sdk/lib/_internal/js_shared/lib/convert_utf_patch.dart
+++ b/sdk/lib/_internal/js_shared/lib/convert_utf_patch.dart
@@ -11,6 +11,12 @@ import 'dart:_native_typed_data' show NativeUint8List;
 class Utf8Decoder {
   @patch
   Converter<List<int>, T> fuse<T>(Converter<String, T> next) {
+    if (next is JsonDecoder) {
+      return JsonUtf8Decoder(
+        (next as JsonDecoder)._reviver,
+        this._allowMalformed,
+      ) as dynamic /*=Converter<List<int>, T>*/;
+    }
     return super.fuse<T>(next);
   }
 }

--- a/sdk/lib/_internal/js_shared/lib/convert_utf_patch.dart
+++ b/sdk/lib/_internal/js_shared/lib/convert_utf_patch.dart
@@ -11,12 +11,6 @@ import 'dart:_native_typed_data' show NativeUint8List;
 class Utf8Decoder {
   @patch
   Converter<List<int>, T> fuse<T>(Converter<String, T> next) {
-    if (next is JsonDecoder) {
-      return JsonUtf8Decoder(
-        (next as JsonDecoder)._reviver,
-        this._allowMalformed,
-      ) as dynamic /*=Converter<List<int>, T>*/;
-    }
     return super.fuse<T>(next);
   }
 }

--- a/sdk/lib/_internal/vm/lib/convert_patch.dart
+++ b/sdk/lib/_internal/vm/lib/convert_patch.dart
@@ -51,6 +51,14 @@ class Utf8Decoder {
 @patch
 class JsonUtf8Decoder {
   @patch
+  Object? convert(List<int> input) {
+    var parser = _JsonUtf8DecoderSink._createParser(reviver, allowMalformed);
+    parser.parseChunk(input, 0, input.length);
+    parser.close();
+    return parser.result;
+  }
+
+  @patch
   ChunkedConversionSink<List<int>> startChunkedConversion(Sink<Object?> sink) {
     return _JsonUtf8DecoderSink(reviver, sink, allowMalformed);
   }

--- a/sdk/lib/_internal/vm/lib/convert_patch.dart
+++ b/sdk/lib/_internal/vm/lib/convert_patch.dart
@@ -74,8 +74,16 @@ class JsonUtf8Decoder {
  * This is a simple stack-based object builder. It keeps the most recently
  * seen value in a variable, and uses it depending on the following event.
  */
+/// Structural nesting limit documented on [JsonUtf8Decoder].
+const int _jsonMaxNestingDepth = 1024;
+
 class _JsonListener {
-  _JsonListener(this.reviver);
+  _JsonListener(this.reviver, {this.maxDepth = _noDepthLimit});
+
+  static const int _noDepthLimit = -1;
+
+  /// Maximum number of nested containers, or [_noDepthLimit].
+  final int maxDepth;
 
   final Object? Function(Object? key, Object? value)? reviver;
 
@@ -99,6 +107,9 @@ class _JsonListener {
 
   /** Pushes the currently active container. */
   void beginContainer() {
+    if (maxDepth != _noDepthLimit && stack.length >= maxDepth) {
+      throw FormatException('Nesting depth exceeds limit of $maxDepth');
+    }
     stack.add(currentContainer);
     currentContainer = [];
   }
@@ -1668,7 +1679,10 @@ class _JsonUtf8DecoderSink extends ByteConversionSink {
     Object? Function(Object? key, Object? value)? reviver,
     bool allowMalformed,
   ) {
-    return _JsonUtf8Parser(_JsonListener(reviver), allowMalformed);
+    return _JsonUtf8Parser(
+      _JsonListener(reviver, maxDepth: _jsonMaxNestingDepth),
+      allowMalformed,
+    );
   }
 
   void addSlice(List<int> chunk, int start, int end, bool isLast) {

--- a/sdk/lib/_internal/wasm/common/convert_patch.dart
+++ b/sdk/lib/_internal/wasm/common/convert_patch.dart
@@ -68,8 +68,16 @@ class JsonUtf8Decoder {
  * This is a simple stack-based object builder. It keeps the most recently
  * seen value in a variable, and uses it depending on the following event.
  */
+/// Structural nesting limit documented on [JsonUtf8Decoder].
+const int _jsonMaxNestingDepth = 1024;
+
 class _JsonListener {
-  _JsonListener(this.reviver);
+  _JsonListener(this.reviver, {this.maxDepth = _noDepthLimit});
+
+  static const int _noDepthLimit = -1;
+
+  /// Maximum number of nested containers, or [_noDepthLimit].
+  final int maxDepth;
 
   final Object? Function(Object? key, Object? value)? reviver;
 
@@ -129,6 +137,9 @@ class _JsonListener {
 
   /** Pushes the currently active container. */
   void beginContainer() {
+    if (maxDepth != _noDepthLimit && stackLength >= maxDepth) {
+      throw FormatException('Nesting depth exceeds limit of $maxDepth');
+    }
     stackPush(currentContainer, currentContainerLength);
     currentContainer = const WasmArray<Object?>.literal([]);
     currentContainerLength = 0;
@@ -2068,7 +2079,10 @@ class _JsonUtf8DecoderSink extends ByteConversionSink {
   static _JsonUtf8Parser _createParser(
     Object? Function(Object? key, Object? value)? reviver,
     bool allowMalformed,
-  ) => _JsonUtf8Parser(_JsonListener(reviver), allowMalformed);
+  ) => _JsonUtf8Parser(
+    _JsonListener(reviver, maxDepth: _jsonMaxNestingDepth),
+    allowMalformed,
+  );
 
   void addSlice(List<int> chunk, int start, int end, bool isLast) {
     _addChunk(chunk, start, end);

--- a/sdk/lib/_internal/wasm/common/convert_patch.dart
+++ b/sdk/lib/_internal/wasm/common/convert_patch.dart
@@ -46,6 +46,14 @@ class Utf8Decoder {
 @patch
 class JsonUtf8Decoder {
   @patch
+  Object? convert(List<int> input) {
+    var parser = _JsonUtf8DecoderSink._createParser(reviver, allowMalformed);
+    parser.parseChunk(input, 0, input.length);
+    parser.close();
+    return parser.result;
+  }
+
+  @patch
   ChunkedConversionSink<List<int>> startChunkedConversion(Sink<Object?> sink) =>
       _JsonUtf8DecoderSink(reviver, sink, allowMalformed);
 }

--- a/sdk/lib/_internal/wasm/js_compatibility/convert_patch.dart
+++ b/sdk/lib/_internal/wasm/js_compatibility/convert_patch.dart
@@ -29,12 +29,6 @@ dynamic _parseJson(
 class Utf8Decoder {
   @patch
   Converter<List<int>, T> fuse<T>(Converter<String, T> next) {
-    if (next is JsonDecoder) {
-      return JsonUtf8Decoder(
-        (next as JsonDecoder)._reviver,
-        this._allowMalformed,
-      ) as dynamic;
-    }
     return super.fuse(next);
   }
 }

--- a/sdk/lib/_internal/wasm/js_compatibility/convert_patch.dart
+++ b/sdk/lib/_internal/wasm/js_compatibility/convert_patch.dart
@@ -26,9 +26,26 @@ dynamic _parseJson(
 }
 
 @patch
+class JsonUtf8Decoder {
+  @patch
+  Object? convert(List<int> input) {
+    // Route through the platform-native string decoder and `JSON.parse`,
+    // which are far faster than the pure-Dart token reader on web.
+    final source = Utf8Decoder(allowMalformed: allowMalformed).convert(input);
+    return _parseJson(source, reviver);
+  }
+}
+
+@patch
 class Utf8Decoder {
   @patch
   Converter<List<int>, T> fuse<T>(Converter<String, T> next) {
+    if (next is JsonDecoder) {
+      return JsonUtf8Decoder(
+        (next as JsonDecoder)._reviver,
+        this._allowMalformed,
+      ) as dynamic;
+    }
     return super.fuse(next);
   }
 }

--- a/sdk/lib/convert/json_utf8.dart
+++ b/sdk/lib/convert/json_utf8.dart
@@ -305,9 +305,11 @@ final class JsonUtf8Decoder extends Converter<List<int>, Object?> {
   /// Decodes [input] directly into Dart objects without creating an
   /// intermediate [String].
   ///
-  /// Enforces a maximum structural nesting depth limit of 1,024 levels of nested
-  /// objects and arrays as a contract guarantee, throwing a [FormatException]
-  /// if input exceeds 1,024 levels of nesting.
+  /// Nesting depth is bounded by the platform decoder: the native VM and
+  /// Wasm decoders reject input nested more than 1,024 levels deep with a
+  /// [FormatException], while web platforms delegate to the JavaScript
+  /// `JSON.parse` and inherit its (effectively unbounded) behavior. Use
+  /// [JsonTokenReader] when a guaranteed 1,024-level limit is required.
   @override
   Object? convert(List<int> input) {
     final bytes = input is Uint8List ? input : Uint8List.fromList(input);


### PR DESCRIPTION
`utf8.decoder.fuse(json.decoder).convert(bytes)` regressed 2–9x on every target because the public `JsonUtf8Decoder.convert()` builds the tree with the Dart-level `JsonTokenReader`, and the platform patches only overrode `startChunkedConversion`.

- **VM / wasm-common**: patch `convert()` to use the existing native `_JsonUtf8Parser` one-shot path (what the old `_JsonUtf8Decoder.convert` did).
- **dart2js / DDC / wasm js_compatibility**: drop the new `Utf8Decoder.fuse` override so the fused path goes back to `TextDecoder` + `JSON.parse`.

## Measured (n=30, stock = 3.14.0-147.0.dev)

Fused decode, ms — stock | before | after

| | AOT | dart2js | dart2wasm |
| :--- | :---: | :---: | :---: |
| twitter | 1.46 / 4.60 / **1.49** | 2.00 / 6.50 / **2.00** | 1.66 / 3.47 / **1.68** |
| citm_catalog | 3.39 / 9.94 / **3.37** | 4.50 / 11.0 / **4.50** | 3.31 / 6.94 / **3.55** |
| canada | 27.6 / 41.3 / **20.6** | 20.5 / 56.5 / **25.0** | 23.8 / 32.3 / **24.7** |

`jsonDecode(String)` and encode paths unaffected. `tools/test.py -mrelease -ax64 lib/convert`: 62/62 pass.